### PR TITLE
CI: create sprint every 2 weeks

### DIFF
--- a/.github/workflows/create-sprint.yml
+++ b/.github/workflows/create-sprint.yml
@@ -16,6 +16,10 @@ jobs:
       - name: Sprint Milestone Action
         # Runs on odd week numbers (so ODD_WEEK = 1)
         if: env.ODD_WEEK == 1
+        # 1) Set the due date in 2 weeks
+        # 2) Get the last sprint number from the one of our repos
+        # 3) Add 1 to the last sprint number
+        # 4) Create the new milestone through GitHub REST API
         run: |
           dueDate=$(date -d "2 weeks" +"%Y-%m-%d") \
           && \

--- a/.github/workflows/create-sprint.yml
+++ b/.github/workflows/create-sprint.yml
@@ -10,18 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get week number
-        # Check if current week number is odd, for running automation every 2 weeks
+        # Determine if current week number is odd or even, for running automation every 2 weeks
         run: echo "ODD_WEEK=$(expr $(date +%U) % 2)" >> $GITHUB_ENV
         
       - name: Sprint Milestone Action
-        # Runs on odd week numbers (so ODD_WEEK = 1)
-        if: env.ODD_WEEK == 1
-        # 1) Set the due date in 2 weeks
+        # Runs on even week numbers (so ODD_WEEK = 0)
+        if: env.ODD_WEEK == 0
+        # 1) Set the due date in 3 weeks (1 week in advance + 2 active weeks)
         # 2) Get the last sprint number from the one of our repos
         # 3) Add 1 to the last sprint number
         # 4) Create the new milestone through GitHub REST API
         run: |
-          dueDate=$(date -d "2 weeks" +"%Y-%m-%d") \
+          dueDate=$(date -d "3 weeks" +"%Y-%m-%d") \
           && \
           lastSprintNumber=$(curl \
           -H "Accept: application/vnd.github.v3+json" \

--- a/.github/workflows/create-sprint.yml
+++ b/.github/workflows/create-sprint.yml
@@ -1,0 +1,35 @@
+name: Create Sprint milestone every 2 weeks on wednesday
+
+on:
+  schedule:
+    # Run script on every wednesday at midnight
+    - cron: '0 0 * * WED'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get week number
+        # Check if current week number is odd, for running automation every 2 weeks
+        run: echo "ODD_WEEK=$(expr $(date +%U) % 2)" >> $GITHUB_ENV
+        
+      - name: Sprint Milestone Action
+        # Runs on odd week numbers (so ODD_WEEK = 1)
+        if: env.ODD_WEEK == 1
+        run: |
+          dueDate=$(date -d "2 weeks" +"%Y-%m-%d") \
+          && \
+          lastSprintNumber=$(curl \
+          -H "Accept: application/vnd.github.v3+json" \
+          -u n1c01a5:${{ secrets.GHPROJECT_TOKEN }} \
+          https://api.github.com/repos/feature-sh/app/milestones \
+          | grep "Sprint" | grep -o -E "[0-9]+" | sort -n | tail -1) \
+          && \
+          newSprintNumber=$(expr $lastSprintNumber + 1) \
+          && \
+          curl \
+          -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -u n1c01a5:${{ secrets.GHPROJECT_TOKEN }} \
+          https://api.github.com/repos/$GITHUB_REPOSITORY/milestones \
+          -d '{"title":"Sprint '"${newSprintNumber}"'","state":"open","description":"","due_on":"'"${dueDate}"'T00:00:00Z"}'

--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@
 ## CI
 
 - [x] Add new issues to GitHub projects beta
+- [x] Create new milestones (sprint) every 2 weeks


### PR DESCRIPTION
It parses the all milestones title and take the highest sprint number. Then, it adds 1 to it for the new milestone's name.